### PR TITLE
Feature/benchmark integration

### DIFF
--- a/app/src/main/cpp/InferenceRunner.h
+++ b/app/src/main/cpp/InferenceRunner.h
@@ -26,11 +26,13 @@ private:
 
     cv::Mat ort_output_to_mat(const Ort::Value &out);
 
-    void start_environment_();
+    void start_environment_(int num_inter_threads, int num_intra_threads,
+                                             GraphOptimizationLevel optimization_level,
+                                             std::string provider_);
 
     cv::Mat decodeBytesToMat_(const std::vector<uint8_t> &bytes, int flags);
 
-    std::vector<uint8_t> encodeMat_(const cv::Mat &img, const std::string &ext, int quality);
+    std::vector<uint8_t> encodeMat_(const cv::Mat &img, const std::string &ext);
 
     std::string model_path_;
     int image_idx_;

--- a/app/src/main/java/com/example/cpponnxrunner/MainActivity.kt
+++ b/app/src/main/java/com/example/cpponnxrunner/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.os.SystemClock
 import android.provider.MediaStore
 import android.util.Log
 import android.view.View
@@ -17,10 +18,10 @@ import com.example.cpponnxrunner.databinding.ActivityMainBinding
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.concurrent.Executors // ADDED
-import android.os.Handler           // ADDED
-import android.os.Looper           // ADDED
-import java.util.Locale            // ADDED
+import java.util.concurrent.Executors
+import android.os.Handler
+import android.os.Looper
+import java.util.Locale
 
 // TODO check optimization flags
 // TODO use NNAPI accelerator

--- a/app/src/main/java/com/example/cpponnxrunner/MainActivity.kt
+++ b/app/src/main/java/com/example/cpponnxrunner/MainActivity.kt
@@ -17,11 +17,15 @@ import com.example.cpponnxrunner.databinding.ActivityMainBinding
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.util.concurrent.Executors // ADDED
+import android.os.Handler           // ADDED
+import android.os.Looper           // ADDED
+import java.util.Locale            // ADDED
 
 // TODO check optimization flags
-// TODO use nnapi accelerator
-// TODO use gpu device
-// TODO port your own onnx model
+// TODO use NNAPI accelerator
+// TODO use GPU device
+// TODO port your own ONNX model
 
 class MainActivity : AppCompatActivity() {
 
@@ -35,30 +39,52 @@ class MainActivity : AppCompatActivity() {
     private val CAPTURE_IMAGE = 2000
     private val CAMERA_PERMISSION_CODE = 8
 
+    // simple background executor and main-thread handler
+    private val bg = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         Log.i("OpenCV", "OpenCV version = ${cvVersion()}")
-        Toast.makeText(this, "OpenCV: ${cvVersion()}", Toast.LENGTH_LONG).show()
+        Toast.makeText(this, "OpenCV version: ${cvVersion()}", Toast.LENGTH_LONG).show()
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         // --- Copy Assets -> Cache ---
         copyAssetToCacheDir(MODEL_ASSET_PATH, "inference.onnx")     // => $cacheDir/inference.onnx
-        copyFileOrDir("images")                                     // => $cacheDir/images/* (for mask and sample input, if you want)
+        copyFileOrDir("images")                                     // => $cacheDir/images/* (for sample input & mask)
 
         val copiedDir = File(cacheDir, "images")
         Log.i("cpponnxrunner", "images dir=${copiedDir.absolutePath} list=${copiedDir.list()?.toList()}")
 
-        // Create Ort session (cache path is provided; the model path is fixed inside SessionCache)
-        createSession("$cacheDir/inference.onnx")
+        // Create ORT session in background; measure duration; show English toasts
+        val modelPath = "$cacheDir/inference.onnx"
+        mainHandler.post {
+            Toast.makeText(this, "Loading model…", Toast.LENGTH_SHORT).show()
+        }
+        val t0Load = SystemClock.elapsedRealtime()
+        bg.execute {
+            try {
+                createSession(modelPath)
+                val dtMs = SystemClock.elapsedRealtime() - t0Load
+                val dtSec = dtMs / 1000.0
+                mainHandler.post {
+                    Toast.makeText(this, String.format(Locale.US, "Model loaded (%.2f s)", dtSec), Toast.LENGTH_LONG).show()
+                }
+            } catch (e: Throwable) {
+                Log.e("cpponnxrunner", "createSession failed", e)
+                mainHandler.post {
+                    Toast.makeText(this, "Model failed to load: ${e.message}", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
 
         val inferButton: Button = findViewById(R.id.infer_button)
         inferButton.setOnClickListener(onInferenceButtonClickedListener)
 
-        // Home screen
+        // Home screen status
         binding.statusMessage.text = "cpponnxrunner"
     }
 
@@ -75,7 +101,7 @@ class MainActivity : AppCompatActivity() {
             val intent = Intent()
             intent.type = "image/*"
             intent.action = Intent.ACTION_GET_CONTENT
-            startActivityForResult(Intent.createChooser(intent, "Select Picture"), PICK_IMAGE)
+            startActivityForResult(Intent.createChooser(intent, "Select Image"), PICK_IMAGE)
         }
     }
 
@@ -109,7 +135,6 @@ class MainActivity : AppCompatActivity() {
                         inp?.readBytes() ?: return
                     }
                 }
-
                 CAPTURE_IMAGE -> {
                     // Camera intent returns a thumbnail; compress to PNG and convert to bytes
                     val bmp = data?.extras?.get("data") as? Bitmap ?: return
@@ -118,37 +143,58 @@ class MainActivity : AppCompatActivity() {
                         bos.toByteArray()
                     }
                 }
-
                 else -> return
             }
+
             // bytes-based infer (assets -> ByteArray -> JNI -> bytes -> cache) ---
             try {
                 val maskBytes: ByteArray = assets.open(SAMPLE_MASK_ASSET).use { it.readBytes() }
                 val imageBytes: ByteArray = assets.open(SAMPLE_IMAGE_ASSET).use { it.readBytes() }
 
-                val outBytes: ByteArray = inferFromBytes(imageBytes, maskBytes)
-                val outPath = writeBytesToCache(OUTPUT_IMAGE_PATH, outBytes)
-
-                Log.i("cpponnxrunner", "Output saved to: $outPath")
-                val outBitmap = BitmapFactory.decodeByteArray(outBytes, 0, outBytes.size)
-                try {
-                    binding.outputImage.setImageBitmap(outBitmap)
-                    binding.statusMessage.text = "Output rendered."
-                } catch (_: Throwable) {
-                    binding.statusMessage.text = "Output saved to: $outPath"
+                // Run inference in background; report duration in seconds
+                mainHandler.post {
+                    Toast.makeText(this, "Inference started…", Toast.LENGTH_SHORT).show()
+                    binding.statusMessage.text = "Running inference…"
                 }
-                val inBitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
-                binding.inputImage.setImageBitmap(inBitmap)
+                val t0Infer = SystemClock.elapsedRealtime()
+                bg.execute {
+                    try {
+                        val outBytes: ByteArray = inferFromBytes(imageBytes, maskBytes)
+                        val outPath = writeBytesToCache(OUTPUT_IMAGE_PATH, outBytes)
+                        val dtMs = SystemClock.elapsedRealtime() - t0Infer
+                        val dtSec = dtMs / 1000.0
 
+                        // UI update (main thread)
+                        mainHandler.post {
+                            Log.i("cpponnxrunner", "Output saved to: $outPath")
+                            val outBitmap = BitmapFactory.decodeByteArray(outBytes, 0, outBytes.size)
+                            try {
+                                binding.outputImage.setImageBitmap(outBitmap)
+                                binding.statusMessage.text = String.format(Locale.US, "Output rendered (%.2f s)", dtSec)
+                            } catch (_: Throwable) {
+                                binding.statusMessage.text = String.format(Locale.US, "Output saved to: %s (%.2f s)", outPath, dtSec)
+                            }
+                            val inBitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                            binding.inputImage.setImageBitmap(inBitmap)
 
                 // Keep the switch on when using the camera
-                if (requestCode == CAPTURE_IMAGE) {
-                    binding.cameraSetting.isChecked = true
+                            if (requestCode == CAPTURE_IMAGE) {
+                                binding.cameraSetting.isChecked = true
+                            }
+                            Toast.makeText(this, String.format(Locale.US, "Inference finished (%.2f s)", dtSec), Toast.LENGTH_LONG).show()
+                        }
+                    } catch (e: Throwable) {
+                        Log.e("cpponnxrunner", "bytes infer failed", e)
+                        mainHandler.post {
+                            binding.statusMessage.text = "Inference error: ${e.message}"
+                            Toast.makeText(this, "Inference error: ${e.message}", Toast.LENGTH_LONG).show()
+                        }
+                    }
                 }
             } catch (t: Throwable) {
-                Log.e("cpponnxrunner", "bytes infer failed", t)
+                Log.e("cpponnxrunner", "bytes infer failed (pre)", t)
+                binding.statusMessage.text = "Byte inference failed: ${t.message}"
             }
-
 
         } catch (t: Throwable) {
             Log.e("cpponnxrunner", "onActivityResult (bytes path) failed", t)
@@ -156,10 +202,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-
     override fun onDestroy() {
         super.onDestroy()
-        try { // destroy stuff
+        try {
+            releaseSession()
         } catch (t: Throwable) {
             Log.w("cpponnxrunner", "releaseSession failed", t)
         }
@@ -197,8 +243,6 @@ class MainActivity : AppCompatActivity() {
                 throw RuntimeException(e)
             }
         }
-
-
         return f.path
     }
 
@@ -222,7 +266,6 @@ class MainActivity : AppCompatActivity() {
         }
         return "$cacheDir/$path"
     }
-
 
     // =========================
     // JNI bridges


### PR DESCRIPTION
Moves ONNX session creation and inference off the main thread.
Adds simple benchmarking with Toasts showing model load and inference durations.
Prevents concurrent runs by adding an isInferencing guard and temporarily disabling the “Infer” button during processing.